### PR TITLE
DO NOT MURGE ABD10: added sample script to run migrations in test env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+/.idea
+/tmp

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # verify-event-store-schema
 
-This repoistory contains the database migrations for Verify's event recording system.
+This repository contains the database migrations for Verify's event recording system.
 
 ## Writing a new migration
 
 To write a new migration simply create a new sql script in the sql directory following [Flyway's naming convention](https://flywaydb.org/documentation/migrations#naming-1)
+
+## Running migrations
+For an example of running migrations, see the scripts/migrate_test.sh script
 

--- a/scripts/migrate_test.sh
+++ b/scripts/migrate_test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -eu
+# this assumes you have the password in a password store :)
+
+BASEDIR=$(dirname $0)/..
+TMPDIR=$BASEDIR/tmp
+rm -rf $TMPDIR
+mkdir -p $TMPDIR
+# TODO: detect if on OSX or Linux
+tar -xzf $BASEDIR/flyway-commandline-5.0.7-macosx-x64.tar.gz -C $TMPDIR
+
+DBURL=jdbc:postgresql://staging-event-recorder-db.cteb6b0pcrlw.eu-west-2.rds.amazonaws.com:5432/events
+
+export FLYWAY_PASSWORD=$(pass show verify/abd/testing_rdb_password)
+$TMPDIR/flyway-5.0.7/flyway migrate \
+    -locations=filesystem:$BASEDIR/sql \
+    -url=$DBURL \
+    -user=postgres

--- a/scripts/migrate_test.sh
+++ b/scripts/migrate_test.sh
@@ -8,7 +8,7 @@ TMPDIR=$BASEDIR/tmp
 rm -rf $TMPDIR
 mkdir -p $TMPDIR
 # TODO: detect if on OSX or Linux
-tar -xzf $BASEDIR/flyway-commandline-5.0.7-macosx-x64.tar.gz -C $TMPDIR
+tar -xzf $BASEDIR/flyway-commandline-5.0.7.tar.gz -C $TMPDIR
 
 DBURL=jdbc:postgresql://staging-event-recorder-db.cteb6b0pcrlw.eu-west-2.rds.amazonaws.com:5432/events
 


### PR DESCRIPTION
Note I've followed the existing practice of checking in the platform-specific flyway binary.

We really should be using the jre-less binary as it's cross-platform (if you have Java!) and much smaller.  But this gets us going for now.